### PR TITLE
Subspecs cleanup

### DIFF
--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -24,7 +24,7 @@ Pod::HooksManager.register('cocoapods-rome', :post_install) do |installer_contex
         xcodebuild(sandbox, target_label, DEVICE)
         xcodebuild(sandbox, target_label, SIMULATOR)
 
-        spec_names = target.specs.map { |spec| Pod::Specification.root_name(spec.name) }
+        spec_names = target.specs.map { |spec| spec.root.name }
         spec_names.uniq.each do |root_name|
           executable_path = "#{build_dir}/#{root_name}"
           device_lib = "#{build_dir}/#{CONFIGURATION}-#{DEVICE}/#{target_label}/#{root_name}.framework/#{root_name}"

--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -42,8 +42,6 @@ Pod::HooksManager.register('cocoapods-rome', :post_install) do |installer_contex
     end
   end
 
-  exit 1
-
   raise Pod::Informative, 'The build directory was not found in the expected location.' unless build_dir.directory?
 
   frameworks = Pathname.glob("#{build_dir}/*.framework").reject { |f| f.to_s =~ /Pods*\.framework/ }


### PR DESCRIPTION
This covers some of the same stuff as https://github.com/neonichu/Rome/pull/11/ but I've also extracted some of the constants that were used multiple times. There's still 1 issue with this that it doesn't work correctly with dependencies (like Fabric/Crashlytics) that are precompiled binaries.

On the subspecs front I believe we also need the `uniq` I have in this script for specs that have a default subspec (my test has been `APAddressBook`)