### PR TITLE
Use module_name instead of name

### DIFF
--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -24,7 +24,7 @@ Pod::HooksManager.register('cocoapods-rome', :post_install) do |installer_contex
         xcodebuild(sandbox, target_label, DEVICE)
         xcodebuild(sandbox, target_label, SIMULATOR)
 
-        spec_names = target.specs.map { |spec| spec.root.name }.uniq
+        spec_names = target.specs.map { |spec| spec.root.module_name }.uniq
         spec_names.each do |root_name|
           executable_path = "#{build_dir}/#{root_name}"
           device_lib = "#{build_dir}/#{CONFIGURATION}-#{DEVICE}/#{target_label}/#{root_name}.framework/#{root_name}"


### PR DESCRIPTION
Fix issue with missing slices when module name is different from spec name, eg: spec name is `HanekeSwift` but module is `Haneke`