### PR TITLE
Support for CocoaPods 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ platform :osx, '10.10'
 
 plugin 'cocoapods-rome'
 
-pod 'Alamofire'
+target 'caesar' do
+  pod 'Alamofire'
+end
 ```
 
 then run this:

--- a/lib/cocoapods-rome/pre_install.rb
+++ b/lib/cocoapods-rome/pre_install.rb
@@ -1,7 +1,6 @@
 Pod::HooksManager.register('cocoapods-rome', :pre_install) do |installer_context|
   podfile = installer_context.podfile
   podfile.use_frameworks!
-  podfile.install!('cocoapods', {
-    :integrate_targets => false
-  })
+  podfile.install!('cocoapods',
+    podfile.installation_method.last.merge(:integrate_targets => false))
 end

--- a/lib/cocoapods-rome/pre_install.rb
+++ b/lib/cocoapods-rome/pre_install.rb
@@ -1,5 +1,7 @@
 Pod::HooksManager.register('cocoapods-rome', :pre_install) do |installer_context|
-  installer_context.podfile.use_frameworks!
-  Pod::Config.instance.integrate_targets = false
-  Pod::Config.instance.deduplicate_targets = false
+  podfile = installer_context.podfile
+  podfile.use_frameworks!
+  podfile.install!('cocoapods', {
+    :integrate_targets => false
+  })
 end


### PR DESCRIPTION
- Use installation options
- No longer set `deduplicate_targets` to `false`
- Update README with explicit target

Will be merged and released once CP 1.0 is final — until then you can clone this branch locally and run `rake install`.