### PR TITLE
Fix issue when uploading built frameworks to ITC.

### DIFF
--- a/lib/cocoapods-rome/post_install.rb
+++ b/lib/cocoapods-rome/post_install.rb
@@ -62,8 +62,10 @@ Pod::HooksManager.register('cocoapods-rome', :post_install) do |installer_contex
 
   raise Pod::Informative, 'The build directory was not found in the expected location.' unless build_dir.directory?
 
-  frameworks = Pathname.glob("#{build_dir}/**/*.framework").reject { |f| f.to_s =~ /Pods.*\.framework/ }
-
+  # Make sure the device target overwrites anything in the simulator build, otherwise iTunesConnect
+  # can get upset about Info.plist containing references to the simulator SDK
+  frameworks = Pathname.glob("build/*/*/*.framework").reject { |f| f.to_s =~ /Pods.*\.framework/ }
+  frameworks += Pathname.glob("build/*.framework").reject { |f| f.to_s =~ /Pods.*\.framework/ }
   Pod::UI.puts "Built #{frameworks.count} #{'frameworks'.pluralize(frameworks.count)}"
 
   destination.rmtree if destination.directory?


### PR DESCRIPTION
Because the order in which the frameworks were copied (simulator vs
device) could vary, sometimes we ended up with the Info.plist used by
the simulator, which upsets iTunesConnect with the following message:

[12:54:45]: ERROR ITMS-90542: "Invalid CFBundleSupportedPlatforms value. The key 'CFBundleSupportedPlatforms' in the Info.plist file in bundle 'Payload/Skyscanner.app/Frameworks/OAStackView.framework/OAStackView.bundle' contains an invalid value '[iPhoneSimulator]'. Consider removing the CFBundleSupportedPlatforms key from the Info.plist. If this bundle is part of a third-party framework, consider contacting the developer of the framework for an update to address this issue."

Fix is to copy the simulator frameworks first, so the device Info.plist
overwrites it.