### PR TITLE
Update fourflusher to 2.2 for Xcode 10.2 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,13 +3,13 @@ PATH
   specs:
     cocoapods-rome (1.0.1)
       cocoapods (>= 1.1.0, < 2.0)
-      fourflusher (~> 2.0)
+      fourflusher (~> 2.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.0)
-    activesupport (4.2.10)
+    activesupport (4.2.11.1)
       i18n (~> 0.7)
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
@@ -17,43 +17,43 @@ GEM
     atomos (0.1.3)
     bacon (1.2.0)
     claide (1.0.2)
-    cocoapods (1.5.3)
+    cocoapods (1.6.1)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.5.3)
+      cocoapods-core (= 1.6.1)
       cocoapods-deintegrate (>= 1.0.2, < 2.0)
-      cocoapods-downloader (>= 1.2.0, < 2.0)
+      cocoapods-downloader (>= 1.2.2, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
       cocoapods-search (>= 1.0.0, < 2.0)
       cocoapods-stats (>= 1.0.0, < 2.0)
-      cocoapods-trunk (>= 1.3.0, < 2.0)
+      cocoapods-trunk (>= 1.3.1, < 2.0)
       cocoapods-try (>= 1.1.0, < 2.0)
       colored2 (~> 3.1)
       escape (~> 0.0.4)
-      fourflusher (~> 2.0.1)
+      fourflusher (>= 2.2.0, < 3.0)
       gh_inspector (~> 1.0)
-      molinillo (~> 0.6.5)
+      molinillo (~> 0.6.6)
       nap (~> 1.0)
-      ruby-macho (~> 1.1)
-      xcodeproj (>= 1.5.7, < 2.0)
-    cocoapods-core (1.5.3)
+      ruby-macho (~> 1.4)
+      xcodeproj (>= 1.8.1, < 2.0)
+    cocoapods-core (1.6.1)
       activesupport (>= 4.0.2, < 6)
       fuzzy_match (~> 2.0.4)
       nap (~> 1.0)
-    cocoapods-deintegrate (1.0.2)
+    cocoapods-deintegrate (1.0.3)
     cocoapods-downloader (1.2.2)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.0)
-    cocoapods-stats (1.0.0)
+    cocoapods-stats (1.1.0)
     cocoapods-trunk (1.3.1)
       nap (>= 0.8, < 2.0)
       netrc (~> 0.11)
     cocoapods-try (1.1.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.2)
+    concurrent-ruby (1.1.5)
     escape (0.0.4)
-    fourflusher (2.0.1)
+    fourflusher (2.2.0)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     i18n (0.9.5)
@@ -64,11 +64,11 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     rake (11.2.2)
-    ruby-macho (1.3.1)
+    ruby-macho (1.4.0)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    xcodeproj (1.7.0)
+    xcodeproj (1.8.1)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
@@ -80,9 +80,9 @@ PLATFORMS
 
 DEPENDENCIES
   bacon
-  bundler (~> 1.3)
+  bundler (~> 2.0)
   cocoapods-rome!
   rake
 
 BUNDLED WITH
-   1.16.3
+   2.0.1

--- a/cocoapods-rome.gemspec
+++ b/cocoapods-rome.gemspec
@@ -19,7 +19,7 @@ Xcode}
   spec.require_paths = ["lib"]
 
   spec.add_dependency "cocoapods", ">= 1.1.0", "< 2.0"
-  spec.add_dependency "fourflusher", "~> 2.0"
+  spec.add_dependency "fourflusher", "~> 2.2"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"

--- a/cocoapods-rome.gemspec
+++ b/cocoapods-rome.gemspec
@@ -21,6 +21,6 @@ Xcode}
   spec.add_dependency "cocoapods", ">= 1.1.0", "< 2.0"
   spec.add_dependency "fourflusher", "~> 2.2"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake"
 end


### PR DESCRIPTION
It upgrades the dependency to 2.2. The new version of the dependency includes support for Xcode 10.2. This commit specifically: https://github.com/CocoaPods/fourflusher/commit/733ddbcdaefd55ed403fd0b99bd13caf378b33ae